### PR TITLE
bugfix: crc32 doesn't work

### DIFF
--- a/ohc-core/src/main/java/org/caffinitas/ohc/linked/UnsExt7.java
+++ b/ohc-core/src/main/java/org/caffinitas/ohc/linked/UnsExt7.java
@@ -48,7 +48,7 @@ final class UnsExt7 extends UnsExt
     long crc32(long address, long offset, long len)
     {
         CRC32 crc = new CRC32();
-        for (; len-- > 0; len--, offset++)
+        for (; len-- > 0; offset++)
             crc.update(Uns.getByte(address, offset));
         long h = crc.getValue();
         h |= h << 32;


### PR DESCRIPTION
Whe you try to use the CRC32 algorithm, the hash value is not correct because org.caffinitas.ohc.linked.UnsExt7.crc32(long, long, long)  has duplicate len--, so you will never get a correct entry from the cache.

The fixed method is just to remove one of the two 'len--'.