### PR TITLE
Improve lock: replace spin-on-compare-and-set with spin-on-read

### DIFF
--- a/ohc-core/src/main/java/org/caffinitas/ohc/chunked/OffHeapChunkedMap.java
+++ b/ohc-core/src/main/java/org/caffinitas/ohc/chunked/OffHeapChunkedMap.java
@@ -951,7 +951,8 @@ final class OffHeapChunkedMap
             // yield control to other thread.
             // Note: we cannot use LockSupport.parkNanos() as that does not
             // provide nanosecond resolution on Windows.
-            Thread.yield();
+            while(lockFieldUpdater.get(this) != 0L)
+                Thread.yield();
         }
     }
 

--- a/ohc-core/src/main/java/org/caffinitas/ohc/linked/OffHeapLinkedMap.java
+++ b/ohc-core/src/main/java/org/caffinitas/ohc/linked/OffHeapLinkedMap.java
@@ -742,13 +742,15 @@ abstract class OffHeapLinkedMap
             return false;
         while (true)
         {
+
             if (lockFieldUpdater.compareAndSet(this, 0L, t))
                 return true;
 
             // yield control to other thread.
             // Note: we cannot use LockSupport.parkNanos() as that does not
             // provide nanosecond resolution on Windows.
-            Thread.yield();
+            while(lockFieldUpdater.get(this) != 0L)
+                Thread.yield();
         }
     }
 


### PR DESCRIPTION
Improve the spin lock implementation. Replace `spin-on-test-and-set` with `spin-on-read`, it's more friendly with SMP per-CPU cache, and get better performance(almost 3%~7% speed up when running benchmark on my machine(ubuntu 17.10)  under different threads size concurrent).


