### PR TITLE
Remove incorrect doc of `capacity`

### DIFF
--- a/ohc-core/src/main/java/org/caffinitas/ohc/OHCacheBuilder.java
+++ b/ohc-core/src/main/java/org/caffinitas/ohc/OHCacheBuilder.java
@@ -122,11 +122,6 @@ import org.caffinitas.ohc.linked.OHCacheLinkedImpl;
  *         <td>Default ticker using {@code System.nanoTime()} and {@code System.currentTimeMillis()}</td>
  *     </tr>
  *     <tr>
- *         <td>{@code capacity}</td>
- *         <td>Expected number of elements in the cache</td>
- *         <td>No default value, recommended to provide a default value.</td>
- *     </tr>
- *     <tr>
  *         <td>{@code eviction}</td>
  *         <td>Choose the eviction algorithm to use. Available are:
  *         <ul>


### PR DESCRIPTION
Seems the capacity parameter represents cache capacity in bytes instead of the number of elements.